### PR TITLE
Use Array.isArray()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ before_script:
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
 after_script:
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-const isArray = require('isarray');
 const isPlainObject = require('lodash.isplainobject');
 
 function convertArray(array) {
@@ -16,7 +15,7 @@ function toSassValue(value) {
     throw new Error("undefined can't be used");
   } else if (value === null) {
     return 'null';
-  } if (isArray(value)) {
+  } if (Array.isArray(value)) {
     return convertArray(value);
   } else if (isPlainObject(value)) {
     return convertPlainObject(value);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "version": "0.1.3",
   "author": "Yuichi Goto",
   "dependencies": {
-    "isarray": "^2.0.2",
     "lodash.isplainobject": "^4.0.6"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -962,10 +962,6 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
-isarray@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.2.tgz#5aa99638daf2248b10b9598b763a045688ece3ee"
-
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"


### PR DESCRIPTION
This PR makes `sass-var` use `Array.isArray()` instead of `isarray` because Node.js v4 or later supports the function.